### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/expo-build-preview.yml
+++ b/.github/workflows/expo-build-preview.yml
@@ -4,6 +4,8 @@ on:
       - 'develop'
 jobs:
   update:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo


### PR DESCRIPTION
Potential fix for [https://github.com/Abel13/4dinha/security/code-scanning/1](https://github.com/Abel13/4dinha/security/code-scanning/1)

To resolve this issue, add a `permissions:` block restricting GITHUB_TOKEN access as tightly as possible. Since the workflow shown primarily sets up and builds but does not appear to push code back to the repository or interact with PRs/issues, the least privilege is `contents: read`. Place the permissions block under the `jobs.update` section, just above `runs-on: ubuntu-latest`, which will restrict permissions only for this job. Alternatively, you could place it at the workflow root for all jobs in the workflow, but the CodeQL message and best practice prefer the job-level change if only one job exists. This change does not affect the functionality of the CI workflow and simply hardens its security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
